### PR TITLE
refactor(users): reorder imports and update schema types for consistency

### DIFF
--- a/src/domains/users/dto/create-user.dto.ts
+++ b/src/domains/users/dto/create-user.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsEmail, IsBoolean, IsOptional } from 'class-validator';
+import { IsBoolean, IsEmail, IsOptional, IsString } from 'class-validator';
 
 export class CreateUserDto {
     @IsString()
@@ -21,12 +21,12 @@ export class CreateUserDto {
     @IsOptional()
     keepSessionActive?: boolean;
 
-    @IsString()
     @IsOptional()
+    @IsString()
     role?: string;
 
-    @IsString()
     @IsOptional()
+    @IsString()
     course?: string;
 
     @IsString()

--- a/src/domains/users/schemas/user.schema.ts
+++ b/src/domains/users/schemas/user.schema.ts
@@ -1,6 +1,8 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { Document, Schema as MongooseSchema } from 'mongoose';
+import { Document, Schema as MongooseSchema, Types } from 'mongoose';
 import { Activity } from '../../activities/schemas/activity.schema';
+import { Role } from 'src/domains/roles/schemas/role.schema';
+import { Course } from 'src/domains/courses/schemas/course.schema';
 
 @Schema()
 export class User extends Document {
@@ -23,11 +25,11 @@ export class User extends Document {
     @Prop({ default: false })
     keepSessionActive: boolean;
 
-    @Prop({ type: MongooseSchema.Types.ObjectId, ref: 'Role', required: false })
-    role: string;
+    @Prop({ type: MongooseSchema.Types.ObjectId, ref: 'Role', required: false, index: true })
+    role: Types.ObjectId | Role;
 
-    @Prop({ type: MongooseSchema.Types.ObjectId, ref: 'Course', required: false })
-    course: string;
+    @Prop({ type: MongooseSchema.Types.ObjectId, ref: 'Course', required: false, index: true })
+    course: Types.ObjectId | Course;
 
     @Prop({ required: true })
     avatar: string;

--- a/src/domains/users/users.controller.ts
+++ b/src/domains/users/users.controller.ts
@@ -4,6 +4,7 @@ import { EventsGateway } from '../../infrastructure/sockets/events.gateway';
 import { CreateUserDto } from './dto/create-user.dto';
 import { JwtAuthGuard } from '../activities/guard/auth.guard';
 import { UsersService } from './users.service';
+import { User } from './schemas/user.schema';
 
 @Controller('users')
 export class UsersController {
@@ -25,7 +26,7 @@ export class UsersController {
     @UseGuards(JwtAuthGuard)
     async create(@Body() createUserDto: CreateUserDto) {
         return this.usersService.create(createUserDto)
-            .then((response: CreateUserDto) => {
+            .then((response: User) => {
                 if (response) {
                     const data = { message: `Se ha registrado un nuevo usuario al sistema, Usuario: ${response.username}` };
                     this.eventsGateway.emitEvent(data);
@@ -73,7 +74,7 @@ export class UsersController {
         };
 
         const token = this.jwtService.sign(payload, {
-            secret: 'vibra-secret-key', //process.env.JWT_SECRET,
+            secret: process.env.JWT_SECRET,
             expiresIn: '24h' // Token expires in 24 hours
         });
 


### PR DESCRIPTION
Reordered imports in `create-user.dto.ts` for better readability. Updated `user.schema.ts` to use `Types.ObjectId` and added `Role` and `Course` schema references for type safety. Also, fixed the return type in `users.controller.ts` from `CreateUserDto` to `User` and used `process.env.JWT_SECRET` for token signing.